### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,7 @@
 name: Snyk Security Scan
+permissions:
+  contents: read
+  security-events: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/timo-jakob/atlassian-cloud-backup/security/code-scanning/10](https://github.com/timo-jakob/atlassian-cloud-backup/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `security-events: write` for uploading SARIF files to GitHub Code Scanning.

The `permissions` block will be added after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
